### PR TITLE
fix: solve the error: 'any_of' is not a member of 'std' when compiling wsdb

### DIFF
--- a/src/common/value.h
+++ b/src/common/value.h
@@ -22,6 +22,7 @@
 #ifndef WSDB_VALUE_H
 #define WSDB_VALUE_H
 
+#include <algorithm>
 #include <string>
 #include <vector>
 #include "types.h"


### PR DESCRIPTION
In the 514 line of value.h, we use std::any_of function. However, we do not include `algorithm` header file, so there will be an eroor when compile wsdb which says error: 'any_of' is not a member of 'std'. As a result, I add the `algorithm` header file to the value.h so that wsdb can be compiled successfully.