### PR TITLE
test: enhance LRUK replacer Victim test with random Pin sequence

### DIFF
--- a/test/storage/replacer_test.cpp
+++ b/test/storage/replacer_test.cpp
@@ -242,6 +242,39 @@ TEST(ReplacerTest, LRUK)
     ASSERT_EQ(frame_id, 1);
     ASSERT_EQ(replacer.Size(), 0);
   }
+
+  SUB_TEST(MyInfTest){
+    std::unordered_set<frame_id_t> pinned;
+    std::vector<frame_id_t> pinned_list;
+    int cnt=0;
+    for (int i=1000;i>=0;i--) {
+      int x = rand()%1024;
+      if (pinned.find(x)==pinned.end()) {
+        pinned.insert(x);
+        pinned_list.push_back(x);
+        cnt++;
+      }
+      else continue;
+      if(cnt>8){
+        frame_id_t fid;
+        replacer.Victim(&fid);
+        ASSERT_EQ(fid, pinned_list[cnt-9]);
+      }
+      replacer.Pin(x);
+      replacer.Pin(x);
+      replacer.Unpin(x);
+    }
+
+    ASSERT_EQ(replacer.Size(), 8);
+
+    for (int i=0;i<8;i++){
+      frame_id_t fid;
+      replacer.Victim(&fid);
+      ASSERT_EQ(fid, pinned_list[pinned_list.size()-8+i]);
+    }
+
+    ASSERT_EQ(replacer.Size(), 0);
+  }
 }
 
 int main(int argc, char **argv)


### PR DESCRIPTION
The core idea of the added test is to eliminate false positives caused by the non-deterministic iteration order of std::unordered_map.
Because the original tests used very small, sequential frame IDs, an incorrect LRUK implementation could still “pass” simply due to favorable hashing behavior rather than true correctness.

By introducing randomized Pin operations over a larger ID space and verifying that Victim() always returns frames strictly according to LRUK semantics (including correct ordering for entries whose backward-K distance is inf), the new test ensures:

    Deterministic correctness, independent of hash bucket ordering

    Robustness against accidental passes caused by hash collisions or iteration order

    Faithful validation of LRUK’s required selection rule, especially for the “infinite backward distance” case

This expanded test prevents implementations from passing by chance and reliably distinguishes correct from incorrect LRUK behavior.